### PR TITLE
This commit fixes duplicate heading format at the beginning of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # imlab (under heavy development) ![Build Status](https://travis-ci.org/cescript/imlab.svg?branch=master)
 
-===
-IMLAB Image Processing Library
-===
+# IMLAB Image Processing Library
 
 IMLAB is an easy to use computer vision library written purely in C language.
 It is designed to be tiny, simple and brief yet self contained. No addtitional libraries is needed. Most of the fundemental operations on images, vectors, matrice and files are written pureley in C as header files which can be used sepeartely depending on your project specifics.


### PR DESCRIPTION
so that it looks prettier on Github. I also choose to format using #
insted of sequence of ='s. Because it can provide more heading level if it
is needed. See: https://www.markdownguide.org/basic-syntax/